### PR TITLE
Set the correct JSON for the identity

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -17,14 +17,14 @@ type Internal struct {
 	OrgID string `json:"org_id"`
 }
 
-type Root struct {
+type Identity struct {
 	AccountNumber string   `json:"account_number"`
 	Internal      Internal `json:"internal"`
 }
 
 // XRHID is the "identity" pricipal object set by Cloud Platform 3scale
 type XRHID struct {
-	Root          Root     `json:"identity"`
+	Identity Identity     `json:"identity"`
 }
 
 func getErrorText(code int, reason string) string {
@@ -42,7 +42,7 @@ func Get(ctx context.Context) XRHID {
 
 // Identity extracts the X-Rh-Identity header and places the contents into the
 // request context
-func Identity(next http.Handler) http.Handler {
+func EnforceIdentity(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rawHeaders := r.Header["X-Rh-Identity"]
 
@@ -66,12 +66,12 @@ func Identity(next http.Handler) http.Handler {
 			return
 		}
 
-		if jsonData.Root.AccountNumber == "" || jsonData.Root.AccountNumber == "-1" {
+		if jsonData.Identity.AccountNumber == "" || jsonData.Identity.AccountNumber == "-1" {
 			doError(w, 400, "x-rh-identity header has an invalid or missing account number")
 			return
 		}
 
-		if jsonData.Root.Internal.OrgID == "" {
+		if jsonData.Identity.Internal.OrgID == "" {
 			doError(w, 400, "x-rh-identity header has an invalid or missing org_id")
 			return
 		}

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -17,10 +17,14 @@ type Internal struct {
 	OrgID string `json:"org_id"`
 }
 
-// XRHID is the "identity" pricipal object set by Cloud Platform 3scale
-type XRHID struct {
+type Root struct {
 	AccountNumber string   `json:"account_number"`
 	Internal      Internal `json:"internal"`
+}
+
+// XRHID is the "identity" pricipal object set by Cloud Platform 3scale
+type XRHID struct {
+	Root          Root     `json:"identity"`
 }
 
 func getErrorText(code int, reason string) string {
@@ -58,16 +62,16 @@ func Identity(next http.Handler) http.Handler {
 		var jsonData XRHID
 		err = json.Unmarshal(idRaw, &jsonData)
 		if err != nil {
-			doError(w, 400, "x-rh-identity header is does not contain vaild JSON")
+			doError(w, 400, "x-rh-identity header is does not contain valid JSON")
 			return
 		}
 
-		if jsonData.AccountNumber == "" || jsonData.AccountNumber == "-1" {
+		if jsonData.Root.AccountNumber == "" || jsonData.Root.AccountNumber == "-1" {
 			doError(w, 400, "x-rh-identity header has an invalid or missing account number")
 			return
 		}
 
-		if jsonData.Internal.OrgID == "" {
+		if jsonData.Root.Internal.OrgID == "" {
 			doError(w, 400, "x-rh-identity header has an invalid or missing org_id")
 			return
 		}

--- a/identity/identity_suite_test.go
+++ b/identity/identity_suite_test.go
@@ -27,7 +27,7 @@ func GetTestHandler(allowPass bool) http.HandlerFunc {
 func boilerWithCustomHandler(req *http.Request, expectedStatusCode int, expectedBody string, handlerFunc http.HandlerFunc) {
 	rr := httptest.NewRecorder()
 
-	handler := identity.Identity(handlerFunc)
+	handler := identity.EnforceIdentity(handlerFunc)
 	handler.ServeHTTP(rr, req)
 
 	Expect(rr.Body.String()).To(Equal(expectedBody))
@@ -37,7 +37,7 @@ func boilerWithCustomHandler(req *http.Request, expectedStatusCode int, expected
 
 func boiler(req *http.Request, expectedStatusCode int, expectedBody string) {
 	rr := httptest.NewRecorder()
-	handler := identity.Identity(GetTestHandler(expectedStatusCode == 200))
+	handler := identity.EnforceIdentity(GetTestHandler(expectedStatusCode == 200))
 	handler.ServeHTTP(rr, req)
 
 	Expect(rr.Code).To(Equal(expectedStatusCode))
@@ -71,8 +71,8 @@ var _ = Describe("Identity", func() {
 			boilerWithCustomHandler(req, 200, "", func() http.HandlerFunc {
 				fn := func(rw http.ResponseWriter, nreq *http.Request) {
 					id := identity.Get(nreq.Context())
-					Expect(id.Root.Internal.OrgID).To(Equal("1979710"))
-					Expect(id.Root.AccountNumber).To(Equal("540155"))
+					Expect(id.Identity.Internal.OrgID).To(Equal("1979710"))
+					Expect(id.Identity.AccountNumber).To(Equal("540155"))
 				}
 				return http.HandlerFunc(fn)
 			}())

--- a/identity/identity_suite_test.go
+++ b/identity/identity_suite_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const validJson = `{ "account_number": "540155", "type": "User", "internal": { "org_id": "1979710" } }`
+const validJson = `{ "identity": {"account_number": "540155", "type": "User", "internal": { "org_id": "1979710" } } }`
 
 func GetTestHandler(allowPass bool) http.HandlerFunc {
 	fn := func(rw http.ResponseWriter, req *http.Request) {
@@ -71,8 +71,8 @@ var _ = Describe("Identity", func() {
 			boilerWithCustomHandler(req, 200, "", func() http.HandlerFunc {
 				fn := func(rw http.ResponseWriter, nreq *http.Request) {
 					id := identity.Get(nreq.Context())
-					Expect(id.Internal.OrgID).To(Equal("1979710"))
-					Expect(id.AccountNumber).To(Equal("540155"))
+					Expect(id.Root.Internal.OrgID).To(Equal("1979710"))
+					Expect(id.Root.AccountNumber).To(Equal("540155"))
 				}
 				return http.HandlerFunc(fn)
 			}())
@@ -95,7 +95,7 @@ var _ = Describe("Identity", func() {
 	Context("With invalid json data (valid b64) in the x-rh-id header", func() {
 		It("should throw a 400 with a descriptive message", func() {
 			req.Header.Set("x-rh-identity", getBase64(validJson+"}"))
-			boiler(req, 400, "Bad Request: x-rh-identity header is does not contain vaild JSON\n")
+			boiler(req, 400, "Bad Request: x-rh-identity header is does not contain valid JSON\n")
 		})
 	})
 


### PR DESCRIPTION
Needed to add a key for "identity" since the rest of the identity is
wrapped in another dict under that

`{"identity": {"account_number": "0000001"}}`