### PR TITLE
[fix] catch and retry batches if we get a bad token

### DIFF
--- a/logging/cloudwatch/hook.go
+++ b/logging/cloudwatch/hook.go
@@ -163,6 +163,7 @@ func (h *Hook) sendBatch(batch []*cloudwatchlogs.InputLogEvent) {
 	h.m.Lock()
 
 	if len(batch) == 0 {
+		h.m.Unlock()
 		return
 	}
 	params := &cloudwatchlogs.PutLogEventsInput{

--- a/logging/cloudwatch/hook.go
+++ b/logging/cloudwatch/hook.go
@@ -173,7 +173,7 @@ func (h *Hook) sendBatch(batch []*cloudwatchlogs.InputLogEvent) {
 	}
 	resp, err := h.svc.PutLogEvents(params)
 	if err == nil {
-		h.NextSequenceToken = resp.NextSequenceToken
+		h.nextSequenceToken = resp.NextSequenceToken
 		h.m.Unlock()
 		return
 	}
@@ -182,7 +182,7 @@ func (h *Hook) sendBatch(batch []*cloudwatchlogs.InputLogEvent) {
 	if aerr, ok := err.(*cloudwatchlogs.InvalidSequenceTokenException); ok {
 		h.nextSequenceToken = aerr.ExpectedSequenceToken
 		h.m.Unlock()
-		h.sendBatch()
+		h.sendBatch(batch)
 		return
 	}
 	


### PR DESCRIPTION
It's possible for the sequence tokens to get out of whack if multiple
process write to the log stream. We avoided this by having each pod
write to it's own log stream, but this still comes up on occassion.

This fix will retry the batch if we encounter the invalid token error
and reset the sequence token to the expected sequence token.

RHCLOUD-12772

Signed-off-by: Stephen Adams <tsadams@gmail.com>