### PR TITLE
Add GetIdentityHeader function

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -85,8 +85,7 @@ func GetIdentityHeader(ctx context.Context) string {
 		if err != nil {
 			return ""
 		}
-		base64.StdEncoding.Encode(identityHeaders, identityHeaders)
-		return string(identityHeaders)
+		return base64.StdEncoding.EncodeToString(identityHeaders)
 	}
 	return ""
 }

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -76,6 +76,21 @@ func Get(ctx context.Context) XRHID {
 	return ctx.Value(Key).(XRHID)
 }
 
+// GetIdentityHeader returns the identity header from the given context if one is present.
+// Can be used to retrieve the header and pass it forward to other applications.
+// Returns the empty string if identity headers cannot be found.
+func GetIdentityHeader(ctx context.Context) string {
+	if xrhid, ok := ctx.Value(Key).(XRHID); ok {
+		identityHeaders, err := json.Marshal(xrhid)
+		if err != nil {
+			return ""
+		}
+		base64.StdEncoding.Encode(identityHeaders, identityHeaders)
+		return string(identityHeaders)
+	}
+	return ""
+}
+
 func checkHeader(id *XRHID, w http.ResponseWriter) error {
 
 	if id.Identity.Type == "Associate" && id.Identity.AccountNumber == "" {

--- a/identity/identity_suite_test.go
+++ b/identity/identity_suite_test.go
@@ -83,11 +83,32 @@ var _ = Describe("Identity", func() {
 				}())
 			}
 		})
-	})
+		It("should be able to return the header again if headers are requested", func() {
+			for _, jsonIdentity := range validJson {
+				req.Header.Set("x-rh-identity", getBase64(jsonIdentity))
 
+				boilerWithCustomHandler(req, 200, "", func() http.HandlerFunc {
+					fn := func(rw http.ResponseWriter, nreq *http.Request) {
+						h := identity.GetIdentityHeader(nreq.Context())
+						Expect(h).ToNot(BeEmpty())
+					}
+					return http.HandlerFunc(fn)
+				}())
+			}
+		})
+	})
 	Context("With a missing x-rh-id header", func() {
 		It("should throw a 400 with a descriptive message", func() {
 			boiler(req, 400, "Bad Request: missing x-rh-identity header\n")
+		})
+		It("should return empty string if headers are requested", func() {
+			boilerWithCustomHandler(req, 400, "Bad Request: missing x-rh-identity header\n", func() http.HandlerFunc {
+				fn := func(rw http.ResponseWriter, nreq *http.Request) {
+					h := identity.GetIdentityHeader(nreq.Context())
+					Expect(h).To(BeEmpty())
+				}
+				return http.HandlerFunc(fn)
+			}())
 		})
 	})
 
@@ -105,6 +126,18 @@ var _ = Describe("Identity", func() {
 			for _, jsonIdentity := range validJson {
 				req.Header.Set("x-rh-identity", getBase64(jsonIdentity+"}"))
 				boiler(req, 400, "Bad Request: x-rh-identity header is does not contain valid JSON\n")
+			}
+		})
+		It("should return empty string if headers are requested", func() {
+			for _, jsonIdentity := range validJson {
+				req.Header.Set("x-rh-identity", getBase64(jsonIdentity+"}"))
+				boilerWithCustomHandler(req, 400, "Bad Request: x-rh-identity header is does not contain valid JSON\n", func() http.HandlerFunc {
+					fn := func(rw http.ResponseWriter, nreq *http.Request) {
+						h := identity.GetIdentityHeader(nreq.Context())
+						Expect(h).To(BeEmpty())
+					}
+					return http.HandlerFunc(fn)
+				}())
 			}
 		})
 	})


### PR DESCRIPTION
We needed this code in our application and I thought it'd be a good addition to the middleware.

I'd like to add a test, but I only found one test suite that seems a lot more focused on testing the requests. I can add a new test suite if that's the case - should it go in the same file (identity_suite_test.go) or a different file?