### PR TITLE
Suppress InvalidSequenceTokenException in CloudWatch/hook.go

### DIFF
--- a/logging/cloudwatch/hook.go
+++ b/logging/cloudwatch/hook.go
@@ -210,9 +210,13 @@ func (h *Hook) Write(p []byte) (n int, err error) {
 	if h.ch != nil {
 		h.ch <- event
 		if h.err != nil {
-			lastErr := h.err
+			lastErr := *h.err
 			h.err = nil
-			return 0, fmt.Errorf("%v", *lastErr)
+			if _, ok := lastErr.(*cloudwatchlogs.InvalidSequenceTokenException); ok {
+				return len(p), nil
+			}
+
+			return 0, fmt.Errorf("%v", lastErr)
 		}
 		return len(p), nil
 	}


### PR DESCRIPTION
Error is present with multiple requests/CloudWatch connections `InvalidSequenceTokenException `on this line:
https://github.com/RedHatInsights/platform-go-middlewares/blob/master/logging/cloudwatch/hook.go#L213

In this case logs are sent to cloudwatch successfully (or at least sent to process by sendBatch through channel `h.ch`) but error is returned and displayed - which is undesirable.

Error:
`InvalidSequenceTokenException`

```
Failed to fire hook: InvalidSequenceTokenException: The given sequenceToken is invalid. The next expected sequenceToken is: 49611013085122989219357090845167240971201614806094184850
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "17d77acd-41af-40c4-900d-6c6cd4fb78c9"
  },
  ExpectedSequenceToken: "49611013085122989219357090845167240971201614806094184850",
  Message_: "The given sequenceToken is invalid. The next expected sequenceToken is: 49611013085122989219357090845167240971201614806094184850"
}
```

# Links
https://github.com/RedHatInsights/platform-go-middlewares/pull/15
https://issues.redhat.com/browse/RHCLOUD-16717

cc @SteveHNH 

