### PR TITLE
add support for top level org_id field

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -46,6 +46,7 @@ type X509 struct {
 // Identity is the main body of the XRHID
 type Identity struct {
 	AccountNumber string                 `json:"account_number"`
+	OrgID         string                 `json:"org_id"`
 	Internal      Internal               `json:"internal"`
 	User          User                   `json:"user,omitempty"`
 	System        map[string]interface{} `json:"system,omitempty"`
@@ -100,7 +101,7 @@ func checkHeader(id *XRHID, w http.ResponseWriter) error {
 		return doError(w, 400, "x-rh-identity header has an invalid or missing account number")
 	}
 
-	if id.Identity.Internal.OrgID == "" {
+	if id.Identity.OrgID == "" || id.Identity.Internal.OrgID == "" {
 		return doError(w, 400, "x-rh-identity header has an invalid or missing org_id")
 	}
 


### PR DESCRIPTION
Our gateways are moving the org_id field to the top level of the identity header. This commit adapts the identity middleware to that change.
See https://issues.redhat.com/browse/RHCLOUD-17653 for details.