### PR TITLE
top-level org_id fallback

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -138,6 +138,8 @@ func EnforceIdentity(next http.Handler) http.Handler {
 			return
 		}
 
+		topLevelOrgIDFallback(&jsonData)
+
 		err = checkHeader(&jsonData, w)
 		if err != nil {
 			return
@@ -146,4 +148,12 @@ func EnforceIdentity(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), Key, jsonData)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// if org_id is not defined at the top level, use the internal one
+// https://issues.redhat.com/browse/RHCLOUD-17717
+func topLevelOrgIDFallback(identity *XRHID) {
+	if identity.Identity.OrgID == "" && identity.Identity.Internal.OrgID != "" {
+		identity.Identity.OrgID = identity.Identity.Internal.OrgID
+	}
 }

--- a/identity/identity_suite_test.go
+++ b/identity/identity_suite_test.go
@@ -16,6 +16,7 @@ import (
 var validJson = [...]string{
 	`{ "identity": {"account_number": "540155", "org_id": "1979710", "type": "User", "internal": {"org_id": "1979710"} } }`,
 	`{ "identity": {"account_number": "540155", "org_id": "1979710", "type": "Associate", "internal": {"org_id": "1979710"} } }`,
+	`{ "identity": {"account_number": "540155", "type": "Associate", "internal": {"org_id": "1979710"} } }`,
 }
 
 func GetTestHandler(allowPass bool) http.HandlerFunc {
@@ -175,8 +176,13 @@ var _ = Describe("Identity", func() {
 
 	Context("With missing org_id in the x-rh-id header", func() {
 		It("should throw a 400 with a descriptive message", func() {
-			for _, jsonIdentity := range validJson {
-				req.Header.Set("x-rh-identity", getBase64(strings.Replace(jsonIdentity, `"org_id": "1979710",`, "", 1)))
+			var missingOrgIDJson = [...]string{
+				`{ "identity": {"account_number": "540155", "type": "User", "internal": {} } }`,
+				`{ "identity": {"account_number": "540155", "org_id": "1979710", "type": "User", "internal": {} } }`,
+			}
+
+			for _, jsonIdentity := range missingOrgIDJson {
+				req.Header.Set("x-rh-identity", getBase64(jsonIdentity))
 				boiler(req, 400, "Bad Request: x-rh-identity header has an invalid or missing org_id\n")
 			}
 		})


### PR DESCRIPTION
If the top-level org_id is missing (old client) populate it from the internal one.
This behavior was requested in the identity lib (github.com/RedHatInsights/identity). Backporting here for consistency.