### PR TITLE
Cleanup sendBatch function

### DIFF
--- a/logging/cloudwatch/hook.go
+++ b/logging/cloudwatch/hook.go
@@ -152,18 +152,18 @@ func (h *Hook) putBatches(flush <-chan bool, ticker <-chan time.Time) {
 		case p := <-h.ch:
 			messageSize := len(*p.Message) + 26
 			if size+messageSize >= 1048576 || len(batch) == 10000 {
-				go h.sendBatch(batch)
+				h.sendBatch(batch)
 				batch = nil
 				size = 0
 			}
 			batch = append(batch, p)
 			size += messageSize
 		case <-flush:
-			go h.sendBatch(batch)
+			h.sendBatch(batch)
 			batch = nil
 			size = 0
 		case <-ticker:
-			go h.sendBatch(batch)
+			h.sendBatch(batch)
 			batch = nil
 			size = 0
 		}
@@ -171,10 +171,7 @@ func (h *Hook) putBatches(flush <-chan bool, ticker <-chan time.Time) {
 }
 
 func (h *Hook) sendBatch(batch []*cloudwatchlogs.InputLogEvent) {
-	h.m.Lock()
-
 	if len(batch) == 0 {
-		h.m.Unlock()
 		return
 	}
 	params := &cloudwatchlogs.PutLogEventsInput{
@@ -186,19 +183,15 @@ func (h *Hook) sendBatch(batch []*cloudwatchlogs.InputLogEvent) {
 	resp, err := h.svc.PutLogEvents(params)
 	if err == nil {
 		h.nextSequenceToken = resp.NextSequenceToken
-		h.m.Unlock()
 		return
 	}
 
 	h.err = &err
 	if aerr, ok := err.(*cloudwatchlogs.InvalidSequenceTokenException); ok {
 		h.nextSequenceToken = aerr.ExpectedSequenceToken
-		h.m.Unlock()
 		h.sendBatch(batch)
 		return
 	}
-
-	h.m.Unlock()
 }
 
 func (h *Hook) Write(p []byte) (n int, err error) {


### PR DESCRIPTION
This code has synchronous (no batching) code with a mutex in the Write method which is correct because AWS request is being made with a token, then a new token is stored. This needs to be synchronized to prevent concurrent problems. So far so good.

However, when batching is enabled, method sendBatch is executed in a goroutine and immediately after that a lock is acquired therefore there is no benefit of concurrency here. Goroutines have no effect, therefore I propose to drop this and simply send batches synchronously. This cleans the sendBatch function a bit (I am not sure why defer was not used there).

While I haven't reproduced, this might actually fix an existing bug filed as https://issues.redhat.com/browse/RHCLOUD-16717 - in short, tokens do not match because sending data is not sequential. This patch cleans the code and makes sure the receiver is guaranteed to be always sending sequentially as long as there are not multiple instances of the same group/stream. There is a workaround that just hides the problem: https://github.com/RedHatInsights/platform-go-middlewares/pull/26