### PR TITLE
[task] make auth_type optional

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -63,7 +63,7 @@ type Identity struct {
 	Associate             Associate `json:"associate,omitempty"`
 	X509                  X509      `json:"x509,omitempty"`
 	Type                  string    `json:"type"`
-	AuthType              string    `json:"auth_type"`
+	AuthType              string    `json:"auth_type,omitempty"`
 }
 
 // XRHID is the "identity" pricipal object set by Cloud Platform 3scale


### PR DESCRIPTION
When this change went in, it requires auth_type. It's possible for us to
get some uploads that do not have this field. Mainly some CCX failed
payloads

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>