### PR TITLE
[task] Allow X509 requests without an account

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -105,7 +105,7 @@ func GetIdentityHeader(ctx context.Context) string {
 
 func checkHeader(id *XRHID, w http.ResponseWriter) error {
 
-	if id.Identity.Type == "Associate" && id.Identity.AccountNumber == "" {
+	if (id.Identity.Type == "Associate" || id.Identity.Type == "X509") && id.Identity.AccountNumber == "" {
 		return nil
 	}
 

--- a/identity/identity_suite_test.go
+++ b/identity/identity_suite_test.go
@@ -211,6 +211,18 @@ var _ = Describe("Identity", func() {
 				return http.HandlerFunc(fn)
 			}())
 		})
+
+		It("should 200 and set the type to X509", func() {
+			req.Header.Set("x-rh-identity", getBase64(`{"identity": {"type": "X509"}}`))
+
+			boilerWithCustomHandler(req, 200, "", func() http.HandlerFunc {
+				fn := func(rw http.ResponseWriter, nreq *http.Request) {
+					id := identity.Get(nreq.Context())
+					Expect(id.Identity.Type).To(Equal("X509"))
+				}
+				return http.HandlerFunc(fn)
+			}())
+		})
 	})
 
 	Context("With a -1 account_number in the x-rh-id header", func() {


### PR DESCRIPTION
Tests that use X509 certificates come from turnpike which does not
include org_id or account numbers. We need to account for that

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>