### PR TITLE
refactor: add BatchWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ Branch name: **master**
 * `Key` type is no longer exported, use appropriate functions.
 * Separated parsing and validation into two exported functions.
 * New middleware function `EnforceIdentityWithLogger` with custom logging interface.
+* Separated CloudWatch batch-writing client from the logrus hook data structure.
+  This allows other logging frameworks to use the BatchWriter client, and logrus
+  clients can use both the BatchWriter and the Hook.

--- a/logging/cloudwatch/batch_writer.go
+++ b/logging/cloudwatch/batch_writer.go
@@ -1,0 +1,202 @@
+package cloudwatch
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+)
+
+// BatchWriter is an io.Writer that batch writes log events to the AWS
+// CloudWatch logs API.
+type BatchWriter struct {
+	svc               *cloudwatchlogs.CloudWatchLogs
+	groupName         string
+	streamName        string
+	nextSequenceToken *string
+	m                 sync.Mutex
+	ch                chan *cloudwatchlogs.InputLogEvent
+	flushWG           sync.WaitGroup
+	err               *error
+}
+
+// NewBatchWriter creates an unbuffered BatchWriter with the given group and
+// stream.
+func NewBatchWriter(groupName, streamName string, cfg *aws.Config) (*BatchWriter, error) {
+	return NewBatchWriterWithDuration(groupName, streamName, cfg, 0)
+}
+
+func (h *BatchWriter) getOrCreateCloudWatchLogGroup() (*cloudwatchlogs.DescribeLogStreamsOutput, error) {
+	resp, err := h.svc.DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
+		LogGroupName:        aws.String(h.groupName),
+		LogStreamNamePrefix: aws.String(h.streamName),
+	})
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case cloudwatchlogs.ErrCodeResourceNotFoundException:
+				_, err = h.svc.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
+					LogGroupName: aws.String(h.groupName),
+				})
+				if err != nil {
+					return nil, err
+				}
+				return h.getOrCreateCloudWatchLogGroup()
+			default:
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+	return resp, nil
+
+}
+
+// NewBatchWriterWithDuration creates a BatchWriter with the given group and
+// stream. To create an unbuffered writer, set batchFrequency to 0.
+func NewBatchWriterWithDuration(groupName, streamName string, cfg *aws.Config, batchFrequency time.Duration) (*BatchWriter, error) {
+	sess, err := session.NewSession(cfg)
+	if err != nil {
+		return nil, err
+	}
+	w := &BatchWriter{
+		svc:        cloudwatchlogs.New(sess),
+		groupName:  groupName,
+		streamName: streamName,
+	}
+
+	resp, err := w.getOrCreateCloudWatchLogGroup()
+	if err != nil {
+		return nil, err
+	}
+
+	if batchFrequency > 0 {
+		w.ch = make(chan *cloudwatchlogs.InputLogEvent, 10000)
+		ticker := time.NewTicker(batchFrequency)
+
+		go w.putBatches(ticker.C)
+	}
+
+	// grab the next sequence token
+	if len(resp.LogStreams) > 0 {
+		w.nextSequenceToken = resp.LogStreams[0].UploadSequenceToken
+		return w, nil
+	}
+
+	// create stream if it doesn't exist. the next sequence token will be null
+	_, err = w.svc.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
+		LogGroupName:  aws.String(groupName),
+		LogStreamName: aws.String(streamName),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+// Force flushing of currently stored messages
+func (w *BatchWriter) Flush() error {
+	w.flushWG.Add(1)
+	w.ch <- nil
+	w.flushWG.Wait()
+	if w.err != nil {
+		return *w.err
+	}
+	return nil
+}
+
+func (w *BatchWriter) putBatches(ticker <-chan time.Time) {
+	var batch []*cloudwatchlogs.InputLogEvent
+	size := 0
+	for {
+		select {
+		case p := <-w.ch:
+			if p != nil {
+				messageSize := len(*p.Message) + 26
+				if size+messageSize >= 1048576 || len(batch) == 10000 {
+					w.sendBatch(batch)
+					batch = nil
+					size = 0
+				}
+				batch = append(batch, p)
+				size += messageSize
+			} else {
+				// Flush event (nil)
+				w.sendBatch(batch)
+				w.flushWG.Done()
+				batch = nil
+				size = 0
+			}
+		case <-ticker:
+			w.sendBatch(batch)
+			batch = nil
+			size = 0
+		}
+	}
+}
+
+func (w *BatchWriter) sendBatch(batch []*cloudwatchlogs.InputLogEvent) {
+	if len(batch) == 0 {
+		return
+	}
+	params := &cloudwatchlogs.PutLogEventsInput{
+		LogEvents:     batch,
+		LogGroupName:  aws.String(w.groupName),
+		LogStreamName: aws.String(w.streamName),
+		SequenceToken: w.nextSequenceToken,
+	}
+	resp, err := w.svc.PutLogEvents(params)
+	if err == nil {
+		w.nextSequenceToken = resp.NextSequenceToken
+		return
+	}
+
+	w.err = &err
+	if aerr, ok := err.(*cloudwatchlogs.InvalidSequenceTokenException); ok {
+		w.nextSequenceToken = aerr.ExpectedSequenceToken
+		w.sendBatch(batch)
+		return
+	}
+}
+
+func (w *BatchWriter) Write(p []byte) (n int, err error) {
+	event := &cloudwatchlogs.InputLogEvent{
+		Message:   aws.String(string(p)),
+		Timestamp: aws.Int64(int64(time.Nanosecond) * time.Now().UnixNano() / int64(time.Millisecond)),
+	}
+
+	if w.ch != nil {
+		w.ch <- event
+		if w.err != nil {
+			lastErr := w.err
+			w.err = nil
+			return 0, fmt.Errorf("%v", *lastErr)
+		}
+		return len(p), nil
+	}
+
+	w.m.Lock()
+	defer w.m.Unlock()
+
+	params := &cloudwatchlogs.PutLogEventsInput{
+		LogEvents:     []*cloudwatchlogs.InputLogEvent{event},
+		LogGroupName:  aws.String(w.groupName),
+		LogStreamName: aws.String(w.streamName),
+		SequenceToken: w.nextSequenceToken,
+	}
+	resp, err := w.svc.PutLogEvents(params)
+	if err != nil {
+		return 0, err
+	}
+
+	w.nextSequenceToken = resp.NextSequenceToken
+
+	return len(p), nil
+}

--- a/logging/cloudwatch/hook.go
+++ b/logging/cloudwatch/hook.go
@@ -4,121 +4,37 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sync"
-	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/sirupsen/logrus"
 )
 
-type Hook struct {
-	svc               *cloudwatchlogs.CloudWatchLogs
-	groupName         string
-	streamName        string
-	nextSequenceToken *string
-	m                 sync.Mutex
-	ch                chan *cloudwatchlogs.InputLogEvent
-	flushWG           sync.WaitGroup
-	err               *error
+// LogrusHook implements the logrus.LogrusHook interface, writing lines to its
+// writer.
+type LogrusHook struct {
+	w io.Writer
 }
 
-func NewHookWithDuration(groupName, streamName string, cfg *aws.Config, batchFrequency time.Duration) (*Hook, error) {
-	return NewBatchingHook(groupName, streamName, cfg, batchFrequency)
-}
-
-func NewHook(groupName, streamName string, cfg *aws.Config) (*Hook, error) {
-	return NewBatchingHook(groupName, streamName, cfg, 0)
-}
-
-func (h *Hook) getOrCreateCloudWatchLogGroup() (*cloudwatchlogs.DescribeLogStreamsOutput, error) {
-	resp, err := h.svc.DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
-		LogGroupName:        aws.String(h.groupName),
-		LogStreamNamePrefix: aws.String(h.streamName),
-	})
-
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case cloudwatchlogs.ErrCodeResourceNotFoundException:
-				_, err = h.svc.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
-					LogGroupName: aws.String(h.groupName),
-				})
-				if err != nil {
-					return nil, err
-				}
-				return h.getOrCreateCloudWatchLogGroup()
-			default:
-				return nil, err
-			}
-		} else {
-			return nil, err
-		}
+func NewLogrusHook(w io.Writer) *LogrusHook {
+	return &LogrusHook{
+		w: w,
 	}
-	return resp, nil
-
-}
-
-func NewBatchingHook(groupName, streamName string, cfg *aws.Config, batchFrequency time.Duration) (*Hook, error) {
-	sess, err := session.NewSession(cfg)
-	if err != nil {
-		return nil, err
-	}
-	h := &Hook{
-		svc:        cloudwatchlogs.New(sess),
-		groupName:  groupName,
-		streamName: streamName,
-	}
-
-	resp, err := h.getOrCreateCloudWatchLogGroup()
-	if err != nil {
-		return nil, err
-	}
-
-	if batchFrequency > 0 {
-		h.ch = make(chan *cloudwatchlogs.InputLogEvent, 10000)
-		ticker := time.NewTicker(batchFrequency)
-
-		go h.putBatches(ticker.C)
-	}
-
-	// grab the next sequence token
-	if len(resp.LogStreams) > 0 {
-		h.nextSequenceToken = resp.LogStreams[0].UploadSequenceToken
-		return h, nil
-	}
-
-	// create stream if it doesn't exist. the next sequence token will be null
-	_, err = h.svc.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
-		LogGroupName:  aws.String(groupName),
-		LogStreamName: aws.String(streamName),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return h, nil
 }
 
 // Force flushing of currently stored messages
-func (h *Hook) Flush() error {
-	h.flushWG.Add(1)
-	h.ch <- nil
-	h.flushWG.Wait()
-	if h.err != nil {
-		return *h.err
+func (h *LogrusHook) Flush() error {
+	batchWriter, ok := h.w.(*BatchWriter)
+	if !ok {
+		return fmt.Errorf("cannot cast to *BatchWriter")
 	}
-	return nil
+	return batchWriter.Flush()
 }
 
 // Function alias for compatibility with zap logging
-func (h *Hook) Sync() error {
+func (h *LogrusHook) Sync() error {
 	return h.Flush()
 }
 
-func (h *Hook) Fire(entry *logrus.Entry) error {
+func (h *LogrusHook) Fire(entry *logrus.Entry) error {
 	line, err := entry.String()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to read entry, %v", err)
@@ -137,137 +53,14 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 	case logrus.InfoLevel:
 		fallthrough
 	case logrus.DebugLevel:
-		_, err := h.Write([]byte(line))
+		_, err := h.w.Write([]byte(line))
 		return err
 	default:
 		return nil
 	}
 }
 
-func (h *Hook) putBatches(ticker <-chan time.Time) {
-	var batch []*cloudwatchlogs.InputLogEvent
-	size := 0
-	for {
-		select {
-		case p := <-h.ch:
-			if p != nil {
-				messageSize := len(*p.Message) + 26
-				if size+messageSize >= 1048576 || len(batch) == 10000 {
-					h.sendBatch(batch)
-					batch = nil
-					size = 0
-				}
-				batch = append(batch, p)
-				size += messageSize
-			} else {
-				// Flush event (nil)
-				h.sendBatch(batch)
-				h.flushWG.Done()
-				batch = nil
-				size = 0
-			}
-		case <-ticker:
-			h.sendBatch(batch)
-			batch = nil
-			size = 0
-		}
-	}
-}
-
-func (h *Hook) sendBatch(batch []*cloudwatchlogs.InputLogEvent) {
-	if len(batch) == 0 {
-		return
-	}
-	params := &cloudwatchlogs.PutLogEventsInput{
-		LogEvents:     batch,
-		LogGroupName:  aws.String(h.groupName),
-		LogStreamName: aws.String(h.streamName),
-		SequenceToken: h.nextSequenceToken,
-	}
-	resp, err := h.svc.PutLogEvents(params)
-	if err == nil {
-		h.nextSequenceToken = resp.NextSequenceToken
-		return
-	}
-
-	h.err = &err
-	if aerr, ok := err.(*cloudwatchlogs.InvalidSequenceTokenException); ok {
-		h.nextSequenceToken = aerr.ExpectedSequenceToken
-		h.sendBatch(batch)
-		return
-	}
-}
-
-func (h *Hook) Write(p []byte) (n int, err error) {
-	event := &cloudwatchlogs.InputLogEvent{
-		Message:   aws.String(string(p)),
-		Timestamp: aws.Int64(int64(time.Nanosecond) * time.Now().UnixNano() / int64(time.Millisecond)),
-	}
-
-	if h.ch != nil {
-		h.ch <- event
-		if h.err != nil {
-			lastErr := h.err
-			h.err = nil
-			return 0, fmt.Errorf("%v", *lastErr)
-		}
-		return len(p), nil
-	}
-
-	h.m.Lock()
-	defer h.m.Unlock()
-
-	params := &cloudwatchlogs.PutLogEventsInput{
-		LogEvents:     []*cloudwatchlogs.InputLogEvent{event},
-		LogGroupName:  aws.String(h.groupName),
-		LogStreamName: aws.String(h.streamName),
-		SequenceToken: h.nextSequenceToken,
-	}
-	resp, err := h.svc.PutLogEvents(params)
-	if err != nil {
-		return 0, err
-	}
-
-	h.nextSequenceToken = resp.NextSequenceToken
-
-	return len(p), nil
-}
-
-func (h *Hook) Levels() []logrus.Level {
-	return []logrus.Level{
-		logrus.PanicLevel,
-		logrus.FatalLevel,
-		logrus.ErrorLevel,
-		logrus.WarnLevel,
-		logrus.InfoLevel,
-		logrus.DebugLevel,
-	}
-}
-
-// WriterHook is a hook that just outputs to an io.Writer.
-// This is useful because our formatter outputs the file
-// and line where it was called, and the callstack for a hook
-// is different from the callstack for just writing to logrus.Logger.Out.
-type WriterHook struct {
-	w io.Writer
-}
-
-func NewWriterHook(w io.Writer) *WriterHook {
-	return &WriterHook{w: w}
-}
-
-func (h *WriterHook) Fire(entry *logrus.Entry) error {
-	line, err := entry.String()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to read entry, %v", err)
-		return err
-	}
-
-	_, err = h.w.Write([]byte(line))
-	return err
-}
-
-func (h *WriterHook) Levels() []logrus.Level {
+func (h *LogrusHook) Levels() []logrus.Level {
 	return []logrus.Level{
 		logrus.PanicLevel,
 		logrus.FatalLevel,


### PR DESCRIPTION
Separate the CloudWatch Logs batch-writing client from the logrus
Hook data structure. This allows other logging frameworks to use
the BatchWriter client, and logrus clients can use both the
BatchWriter and the Hook.

### Example Usage

```go
w, err := cloudwatch.NewBatchWriter(groupName, streamName, awsCfg)
hook := cloudwatch.NewLogrusHook(w)
logrus.Hooks.Add(hook)
```

Other logging frameworks can still make use of the CloudWatch logs API client (`BatchWriter`) and don't need to use the logrus hook:

```go
w, err := cloudwatch.NewBatchWriter(groupName, streamName, awsCfg)
zerolog.Out(io.MultiWriter(os.Stderr, w))
```