### PR TITLE
Fix org_id check

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -109,7 +109,7 @@ func checkHeader(id *XRHID, w http.ResponseWriter) error {
 		return nil
 	}
 
-	if id.Identity.OrgID == "" || id.Identity.Internal.OrgID == "" {
+	if id.Identity.OrgID == "" && id.Identity.Internal.OrgID == "" {
 		return doError(w, 400, "x-rh-identity header has an invalid or missing org_id")
 	}
 

--- a/identity/identity_suite_test.go
+++ b/identity/identity_suite_test.go
@@ -228,7 +228,6 @@ var _ = Describe("Identity", func() {
 		It("should throw a 400 with a descriptive message", func() {
 			var missingOrgIDJson = [...]string{
 				`{ "identity": {"account_number": "540155", "type": "User", "internal": {} } }`,
-				`{ "identity": {"account_number": "540155", "org_id": "1979710", "type": "User", "internal": {} } }`,
 			}
 
 			for _, jsonIdentity := range missingOrgIDJson {

--- a/identity/identity_suite_test.go
+++ b/identity/identity_suite_test.go
@@ -54,6 +54,7 @@ var validJson = [...]string{
 	`{ "identity": {"account_number": "540155", "auth_type": "jwt-auth", "org_id": "1979710", "type": "User", "internal": {"org_id": "1979710"} } }`,
 	`{ "identity": {"account_number": "540155", "auth_type": "cert-auth", "org_id": "1979710", "type": "Associate", "internal": {"org_id": "1979710"} } }`,
 	`{ "identity": {"account_number": "540155", "auth_type": "basic-auth", "type": "Associate", "internal": {"org_id": "1979710"} } }`,
+	`{ "identity": {"account_number": "540155", "auth_type": "cert-auth", "org_id": "1979710", "type": "Associate", "internal": {} } }`,
 	exampleHeader,
 }
 
@@ -116,7 +117,6 @@ var _ = Describe("Identity", func() {
 					fn := func(rw http.ResponseWriter, nreq *http.Request) {
 						id := identity.Get(nreq.Context())
 						Expect(id.Identity.OrgID).To(Equal("1979710"))
-						Expect(id.Identity.Internal.OrgID).To(Equal("1979710"))
 						Expect(id.Identity.AccountNumber).To(Equal("540155"))
 					}
 					return http.HandlerFunc(fn)


### PR DESCRIPTION
We should only fail the org_id check when the id is missing completely.
If we have it in the top level, but not in `internal` that should be
okay.

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>