### PR TITLE
Add support for service account identities

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -79,6 +79,12 @@ type X509 struct {
 	IssuerDN  string `json:"issuer_dn"`
 }
 
+// ServiceAccount is the "service_account" field of an XRHID
+type ServiceAccount struct {
+	ClientId string `json:"client_id"`
+	Username string `json:"username"`
+}
+
 // System is the "system" field of an XRHID
 type System struct {
 	CommonName string `json:"cn,omitempty"`
@@ -88,16 +94,17 @@ type System struct {
 
 // Identity is the main body of the XRHID
 type Identity struct {
-	AccountNumber         string    `json:"account_number,omitempty"`
-	EmployeeAccountNumber string    `json:"employee_account_number,omitempty"`
-	OrgID                 string    `json:"org_id"`
-	Internal              Internal  `json:"internal"`
-	User                  User      `json:"user,omitempty"`
-	System                System    `json:"system,omitempty"`
-	Associate             Associate `json:"associate,omitempty"`
-	X509                  X509      `json:"x509,omitempty"`
-	Type                  string    `json:"type"`
-	AuthType              string    `json:"auth_type,omitempty"`
+	AccountNumber         string         `json:"account_number,omitempty"`
+	EmployeeAccountNumber string         `json:"employee_account_number,omitempty"`
+	OrgID                 string         `json:"org_id"`
+	Internal              Internal       `json:"internal"`
+	User                  User           `json:"user,omitempty"`
+	System                System         `json:"system,omitempty"`
+	Associate             Associate      `json:"associate,omitempty"`
+	X509                  X509           `json:"x509,omitempty"`
+	ServiceAccount        ServiceAccount `json:"service_account,omitempty"`
+	Type                  string         `json:"type"`
+	AuthType              string         `json:"auth_type,omitempty"`
 }
 
 // ServiceDetails describe the services the org is entitled to

--- a/identity/identity_suite_test.go
+++ b/identity/identity_suite_test.go
@@ -51,12 +51,29 @@ var exampleHeader = `
 }
 `
 
+var serviceAccountIdentity = `
+{
+  "identity": {
+    "account_number": "540155",
+    "auth_type": "jwt-auth",
+    "internal": {},
+    "org_id": "1979710",
+    "service_account": {
+      "client_id": "0000",
+      "username": "jdoe"
+    },
+    "type": "ServiceAccount"
+  }
+}
+`
+
 var validJson = [...]string{
 	`{ "identity": {"account_number": "540155", "auth_type": "jwt-auth", "org_id": "1979710", "type": "User", "internal": {"org_id": "1979710"} } }`,
 	`{ "identity": {"account_number": "540155", "auth_type": "cert-auth", "org_id": "1979710", "type": "Associate", "internal": {"org_id": "1979710"} } }`,
 	`{ "identity": {"account_number": "540155", "auth_type": "basic-auth", "type": "Associate", "internal": {"org_id": "1979710"} } }`,
 	`{ "identity": {"account_number": "540155", "auth_type": "cert-auth", "org_id": "1979710", "type": "Associate", "internal": {} } }`,
 	exampleHeader,
+	serviceAccountIdentity,
 }
 
 func GetTestHandler(allowPass bool) http.HandlerFunc {
@@ -272,6 +289,20 @@ var _ = Describe("Identity", func() {
 				fn := func(rw http.ResponseWriter, nreq *http.Request) {
 					id := identity.GetIdentity(nreq.Context())
 					Expect(id.Identity.Type).To(Equal("X509"))
+				}
+				return http.HandlerFunc(fn)
+			}())
+		})
+
+		It("should 200 and set the correct values for a ServiceAccount identity", func() {
+			req.Header.Set("x-rh-identity", getBase64(serviceAccountIdentity))
+
+			boilerWithCustomHandler(req, 200, "", func() http.HandlerFunc {
+				fn := func(rw http.ResponseWriter, nreq *http.Request) {
+					id := identity.Get(nreq.Context())
+					Expect(id.Identity.Type).To(Equal("ServiceAccount"))
+					Expect(id.Identity.ServiceAccount.Username).To(Equal("jdoe"))
+					Expect(id.Identity.ServiceAccount.ClientId).To(Equal("0000"))
 				}
 				return http.HandlerFunc(fn)
 			}())


### PR DESCRIPTION
Supports identity type `ServiceAccount` which will have a `service_account` object consisting of `username` and `client_id`. Other top-level fields not specific to the identity type will remain the same as `User` and `System`.

Related PR constructing the `x-rh-identity` for service accounts: https://github.com/RedHatInsights/insights-3scale/pull/297