### PR TITLE
Make service account ommitable

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -94,17 +94,17 @@ type System struct {
 
 // Identity is the main body of the XRHID
 type Identity struct {
-	AccountNumber         string         `json:"account_number,omitempty"`
-	EmployeeAccountNumber string         `json:"employee_account_number,omitempty"`
-	OrgID                 string         `json:"org_id"`
-	Internal              Internal       `json:"internal"`
-	User                  User           `json:"user,omitempty"`
-	System                System         `json:"system,omitempty"`
-	Associate             Associate      `json:"associate,omitempty"`
-	X509                  X509           `json:"x509,omitempty"`
-	ServiceAccount        ServiceAccount `json:"service_account,omitempty"`
-	Type                  string         `json:"type"`
-	AuthType              string         `json:"auth_type,omitempty"`
+	AccountNumber         string          `json:"account_number,omitempty"`
+	EmployeeAccountNumber string          `json:"employee_account_number,omitempty"`
+	OrgID                 string          `json:"org_id"`
+	Internal              Internal        `json:"internal"`
+	User                  *User           `json:"user,omitempty"`
+	System                *System         `json:"system,omitempty"`
+	Associate             *Associate      `json:"associate,omitempty"`
+	X509                  *X509           `json:"x509,omitempty"`
+	ServiceAccount        *ServiceAccount `json:"service_account,omitempty"`
+	Type                  string          `json:"type"`
+	AuthType              string          `json:"auth_type,omitempty"`
 }
 
 // ServiceDetails describe the services the org is entitled to


### PR DESCRIPTION
Guys, I am testing v2 against our app and it turns out RBAC service is unable to parse this:

```
{
  "identity": {
    "account_number": "0369233",
    "org_id": "3340851",
    "internal": {
      "org_id": "3340851",
      "auth_time": 6300
    },
    "user": {
      "username": "jdoe",
      "email": "jdoe@acme.com",
      "first_name": "John",
      "last_name": "Doe",
      "is_active": true,
      "is_org_admin": true,
      "is_internal": false,
      "locale": "en_US",
      "user_id": ""
    },
    "system": {},
    "associate": {
      "Role": null,
      "email": "",
      "givenName": "",
      "rhatUUID": "",
      "surname": ""
    },
    "x509": {
      "subject_dn": "",
      "issuer_dn": ""
    },
    "service_account": {
      "client_id": "",
      "username": ""
    },
    "type": "User",
    "auth_type": "basic-auth"
  },
  "entitlements": {
    "cost_management": {
      "is_entitled": true,
      "is_trial": false
    },
    "hybrid_cloud": {
      "is_entitled": true,
      "is_trial": false
    },
    "insights": {
      "is_entitled": true,
      "is_trial": false
    },
    "openshift": {
      "is_entitled": true,
      "is_trial": false
    },
    "settings": {
      "is_entitled": true,
      "is_trial": false
    },
    "smart_management": {
      "is_entitled": true,
      "is_trial": false
    }
  }
}
```

I figured that non-pointer (embedded) structs are not actually ommitable. I believe a pointer should do the trick, otherwise, no Go service will be able to pass an identity which is in fact not a service indentity.