### PR TITLE
chore: add gobump weekly

### DIFF
--- a/.github/workflows/weekly-bump.yaml
+++ b/.github/workflows/weekly-bump.yaml
@@ -1,0 +1,19 @@
+name: "Weekly gobump"
+on:
+  schedule:
+    - cron: '13 13 * * SUN'
+  workflow_dispatch:
+
+jobs:
+  bump-deps-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run gobump-deps action
+        uses: ./
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          exec: "go test ./..."
+          labels: "gobump"


### PR DESCRIPTION
This adds a weekly gobump job, it is a utility I wrote that bumps dependencies while keeping Go version untouched in `go.mod`. In order for this to work, we need to set GHA token permissions to file PRs from GHA. After this is merged, every Sunday afternoon gobump will run and if there is a dep that can be updated a PR will be filed.

https://github.com/lzap/gobump