### PR TITLE
fix: typo in gobump weekly

### DIFF
--- a/.github/workflows/weekly-bump.yaml
+++ b/.github/workflows/weekly-bump.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run gobump-deps action
-        uses: ./
+        uses: lzap/gobump@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           exec: "go test ./..."


### PR DESCRIPTION
Missed a typo.

Here is a successful run: https://github.com/RedHatInsights/platform-go-middlewares/actions/runs/14852232966/job/41697884793

Here is the result: https://github.com/RedHatInsights/platform-go-middlewares/pull/112
