### PR TITLE
Add missing `user_id` field to ServiceAccount identity

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -83,6 +83,7 @@ type X509 struct {
 type ServiceAccount struct {
 	ClientId string `json:"client_id"`
 	Username string `json:"username"`
+	UserId   string `json:"user_id"`
 }
 
 // System is the "system" field of an XRHID

--- a/identity/identity_suite_test.go
+++ b/identity/identity_suite_test.go
@@ -60,7 +60,8 @@ var serviceAccountIdentity = `
     "org_id": "1979710",
     "service_account": {
       "client_id": "0000",
-      "username": "jdoe"
+      "username": "jdoe",
+      "user_id": "5d16465b-c0be-4cf6-a26f-084ebbc5e67d"
     },
     "type": "ServiceAccount"
   }
@@ -303,6 +304,7 @@ var _ = Describe("Identity", func() {
 					Expect(id.Identity.Type).To(Equal("ServiceAccount"))
 					Expect(id.Identity.ServiceAccount.Username).To(Equal("jdoe"))
 					Expect(id.Identity.ServiceAccount.ClientId).To(Equal("0000"))
+					Expect(id.Identity.ServiceAccount.UserId).To(Equal("5d16465b-c0be-4cf6-a26f-084ebbc5e67d"))
 				}
 				return http.HandlerFunc(fn)
 			}())


### PR DESCRIPTION
The `user_id` filed is required per the identity schema [1], which this adds to the `ServiceAccount` struct.

[1] https://github.com/RedHatInsights/identity-schemas/blob/main/3scale/schema.json#L145